### PR TITLE
Fix workdir when you call the list action twice

### DIFF
--- a/transports/sftp/index.js
+++ b/transports/sftp/index.js
@@ -89,7 +89,7 @@ module.exports = function (RED) {
             let sftp = new Client();
             node.status({ fill: "blue", shape: "dot", text: 'connecting' });
             try {
-                node.workdir = node.workdir || msg.workdir || "./";
+                node.workdir = msg.workdir || node.workdir || "./";
                 node.localFilename = node.localFilename || msg.localFilename || "";
 
                 /* SFTP options */


### PR DESCRIPTION
Hi ! 

First of all, great job ! This node is really useful !

I just fix a bug which occurs when you call the list action twice in a row, with 2 differents workdir , in this case the node re-use the first workdir forever.

Thanks in advance and have a great day !